### PR TITLE
Add support to ActiveModel::API and attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 ## [Unreleased]
 
+## [0.2.0] - 2025-04-04
+
+### Added
+- Added support for `ActiveModel::API` and `ActiveModel::Attributes`
+- Type casting through `ActiveModel::Attributes`
+- Improved validation through `ActiveModel::Validations`
+
+### Changed
+- Service initialization uses keyword arguments exclusively
+- Improved error messages and documentation
+- Enhanced example code in docstrings
+
+### Removed
+- Support for positional arguments in the `call` method
+
+### Breaking Changes
+- Services must now use keyword arguments instead of positional arguments
+- All existing services using positional arguments need to be updated
+
 ## [0.1.0] - 2025-02-04
 
 - Initial release

--- a/lib/application_service.rb
+++ b/lib/application_service.rb
@@ -8,51 +8,57 @@ require "active_model"
 # perform a single action or a series of related actions.
 module ApplicationService
   # The Base class within the ApplicationService module provides a standard
-  # interface for calling service objects. It defines a class method `call`
-  # that initializes a new instance of the service object and invokes its
-  # `call` instance method.
+  # interface for calling service objects with robust type handling and validations.
+  # It leverages ActiveModel::API for initialization with keyword arguments,
+  # ActiveModel::Attributes for type casting, and ActiveModel::Validations for
+  # input validation.
   #
   # Example usage:
   #   class Sum < ApplicationService::Base
-  #     attr_accessor :number_a, :number_b
+  #     attribute :number_a, :integer
+  #     attribute :number_b, :integer
   #
   #     validates :number_a, :number_b, presence: true, numericality: { only_integer: true, greater_than: 0 }
   #
-  #     def initialize(number_a, number_b)
-  #       super
-  #
-  #       self.number_a = number_a
-  #       self.number_b = number_b
-  #     end
-  #
   #     def call
-  #       (number_a + number_b)
+  #       number_a + number_b
   #     end
   #   end
   #
-  #   sum = Sum.call(1, 2) # 2
+  #   sum = Sum.call(number_a: 1, number_b: 2) # => 3
   #
-  # The `call` method can accept any number of arguments, which are
-  # passed to the initializer of the service object. You can define
-  # attributes and validations just like in Active Record, using
-  # the same syntax and conventions.
+  # Available attribute types include:
+  # - :integer
+  # - :float
+  # - :decimal
+  # - :string
+  # - :boolean
+  # - :date
+  # - :time
+  # - :datetime
+  # - and other custom types defined in ActiveModel::Type
   class Base
+    include ::ActiveModel::API
+    include ::ActiveModel::Attributes
     include ::ActiveModel::Validations
 
     # Initializes a new instance of the service object.
     #
-    # @param args [Array] the arguments to be passed to the initializer of the service object
-    # @raise [NotImplementedError] if an attempt is made to instantiate the abstract class directly
-    def initialize(*_args)
-      raise NotImplementedError, "#{self.class} can not be instantiated" if instance_of?(Base)
+    # @param kwargs [Hash] the attributes to be passed to the service object
+    # @raise [NotImplementedError] if an attempt is made to instantiate the Base class directly
+    def initialize(**kwargs)
+      super
+
+      raise ::NotImplementedError, "#{self.class.name} is an abstract class and cannot be instantiated directly" if instance_of?(Base)
     end
 
     # Initializes a new instance of the service object and invokes its `call` method.
     #
-    # @param args [Array] the arguments to be passed to the initializer of the service object
-    # @return [Object] the recently instantiated service object
-    def self.call(*args)
-      service = new(*args)
+    # @param kwargs [Hash] the attributes to be passed to the service object
+    # @return [Object] the result of the service object's call method
+    # @return [false] if the service object is invalid
+    def self.call(**kwargs)
+      service = new(**kwargs)
 
       return false unless service.valid?
 
@@ -63,7 +69,7 @@ module ApplicationService
     #
     # @raise [NotImplementedError] if the method is not implemented in a child class
     def call
-      raise NotImplementedError, "The `call` method must be implemented in #{self.class}"
+      raise ::NotImplementedError, "The `call` method must be implemented in #{self.class.name}"
     end
   end
 end

--- a/spec/service_with_validation_spec.rb
+++ b/spec/service_with_validation_spec.rb
@@ -1,32 +1,31 @@
 # frozen_string_literal: true
 
-class SumWithValidation < ApplicationService::Base
-  attr_accessor :number_a, :number_b
+class SumWithValidation < ::ApplicationService::Base
+  attribute :number_a, :integer
+  attribute :number_b, :integer
 
-  validates :number_a, :number_b, presence: true, numericality: { only_integer: true, greater_than: 0 }
-
-  def initialize(number_a, number_b)
-    super
-
-    self.number_a = number_a
-    self.number_b = number_b
-  end
+  validates :number_a,
+            :number_b, 
+            presence: true,
+            numericality: { 
+              greater_than: 0
+            }
 
   def call
-    (number_a + number_b)
-  rescue StandardError
+    number_a + number_b
+  rescue ::StandardError
     0
   end
 end
 
 RSpec.describe SumWithValidation do
-  it "calculates the sum of two given numbers" do
-    sum = SumWithValidation.call(1, 2)
-    expect(sum).to be_truthy
+  it "calculates the sum of two given number" do
+    sum = SumWithValidation.call(number_a: 1, number_b: 2)
+    expect(sum).to eq(3)
   end
 
   it "fails if no number is given" do
-    sum = SumWithValidation.call(nil, nil)
+    sum = SumWithValidation.call(number_a: nil, number_b: nil)
     expect(sum).to be_falsey
   end
 end

--- a/spec/service_without_validation_spec.rb
+++ b/spec/service_without_validation_spec.rb
@@ -1,30 +1,38 @@
 # frozen_string_literal: true
 
-class SumWithoutValidation < ApplicationService::Base
-  attr_accessor :number_a, :number_b
+class SumWithoutValidation < ::ApplicationService::Base
+  attribute :number_a, :integer
+  attribute :number_b, :integer
 
-  def initialize(number_a, number_b)
-    super
-
-    self.number_a = number_a
-    self.number_b = number_b
-  end
+  validates :number_a, 
+            :number_b,
+            presence: true
 
   def call
-    (number_a + number_b)
-  rescue StandardError
+    number_a + number_b
+  rescue ::StandardError
     0
   end
 end
 
 RSpec.describe SumWithoutValidation do
   it "calculates the sum of two given numbers" do
-    sum = SumWithoutValidation.call(1, 2)
-    expect(sum).to be_truthy
+    sum = SumWithoutValidation.call(number_a: 1, number_b: 2)
+    expect(sum).to eq(3)
   end
 
   it "does not fail if no number is given" do
-    sum = SumWithoutValidation.call(1, nil)
-    expect(sum).to be_truthy
+    sum = SumWithoutValidation.call(number_a: 1, number_b: nil)
+    expect(sum).to be_falsey
+  end
+  
+  it "automatically converts string numbers to integers" do
+    sum = SumWithoutValidation.call(number_a: "5", number_b: "10")
+    expect(sum).to eq(15)
+  end
+  
+  it "handles type conversion automatically" do
+    sum = SumWithoutValidation.call(number_a: 1.5, number_b: "2.8")
+    expect(sum).to eq(3)
   end
 end


### PR DESCRIPTION
## Description

This PR introduces the integration of `ActiveModel::API` and `ActiveModel::Attributes` into the `rails_application_service` gem. These changes bring significant improvements to the design and usage of service objects.

## Main Changes

### **ActiveModel::API**
- Provides a standardized interface for object initialization with attributes.
- Allows initialization with a consistent attribute hash.
- Integrates seamlessly with the Rails ecosystem.

### **ActiveModel::Attributes**
- Adds support for attribute typing.
- Defines a clear contract for the service's input.
- Facilitates automatic type casting.

## Benefits

### **Design by Contract**
Switching to keyword arguments enforces a well-defined contract between the caller and the service. For example:

```ruby
# Before (positional)
Sum.call(1, 2) # Fragile - depends on argument order

# After (keyword arguments)
Sum.call(number_a: 1, number_b: 2) # Explicit contract
```

## Typing and Validation
With `ActiveModel::Attributes`, we can clearly define the expected types:

```ruby
class Sum < ApplicationService::Base
  attribute :number_a, :integer
  attribute :number_b, :integer
  # ...
end
```

## Better Documentation
Using keyword arguments makes the code more self-documenting, as:

- Parameter names are explicit.
- Argument order no longer matters.
- It's easier to understand what each parameter represents.

```ruby
class Sum < ApplicationService::Base
  attribute :number_a, :integer
  attribute :number_b, :integer

  validates :number_a, :number_b, 
            presence: true,
            numericality: { greater_than: 0 }

  def call
    number_a + number_b
  end
end

# Usage with explicit contract
result = Sum.call(number_a: 1, number_b: 2) # => 3

# Example with validation errors
sum = Sum.new(number_a: -1, number_b: 2)
sum.valid? # => false
sum.errors.full_messages # => ["Number a must be greater than 0"]
```

## Breaking Changes

This change introduces a breaking change: services that previously used positional arguments will now need to use keyword arguments. We recommend reviewing the services in your application to make these adjustments. If necessary, we can add deprecation warnings in future versions to assist with the transition.

## How to Migrate
To migrate existing services:

1. Replace attr_accessor with attribute for the appropriate type.
2. Update method calls to use keyword arguments instead of positional arguments.
